### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/test/manual/additional_trust_anchors/test.py
+++ b/test/manual/additional_trust_anchors/test.py
@@ -34,12 +34,12 @@ write_file('index.html', index_html)
 # test with trust anchors
 ca = read_ca_cert()
 pkg_with_trust_anchors = '''
-{
+{{
   "name": "test_additional_trust_anchors",
   "main": "index.html",
-  "additional_trust_anchors": ["%s"]
-}
-''' % ca
+  "additional_trust_anchors": ["{0!s}"]
+}}
+'''.format(ca)
 write_file('package.json', pkg_with_trust_anchors)
 
 driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])

--- a/test/remoting/app-argv/test.py
+++ b/test/remoting/app-argv/test.py
@@ -12,10 +12,10 @@ time.sleep(1)
 try:
     print driver.current_url
     result = driver.find_element_by_id('result-argv').get_attribute('innerHTML')
-    print 'nw.App.argv = %s' % result
+    print 'nw.App.argv = {0!s}'.format(result)
     assert('nwapp=' not in result)
     result = driver.find_element_by_id('result-fullargv').get_attribute('innerHTML')
-    print 'nw.App.fullArgv = %s' % result
+    print 'nw.App.fullArgv = {0!s}'.format(result)
     assert('nwapp=' in result)
 finally:
     driver.quit()

--- a/test/remoting/clipboard/test.py
+++ b/test/remoting/clipboard/test.py
@@ -18,7 +18,7 @@ def assert_dom_not(id, not_expect):
 
 def test_get_text():
   id = 'test-get-text'
-  script = 'getText("%s")' % id
+  script = 'getText("{0!s}")'.format(id)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
@@ -26,12 +26,12 @@ def test_get_text():
 def test_set_text():
   id = 'test-set-text-1'
   value = 'abc'
-  script = 'setText("%s", "%s")' % (id, value)
+  script = 'setText("{0!s}", "{1!s}")'.format(id, value)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
   id = 'test-set-text-2'
-  script = 'getText("%s")' % id
+  script = 'getText("{0!s}")'.format(id)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
@@ -40,24 +40,24 @@ def test_set_text():
 def test_clear():
   id = 'test-clear-1'
   value = 'abc'
-  script = 'setText("%s", "%s")' % (id, value)
+  script = 'setText("{0!s}", "{1!s}")'.format(id, value)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
   id = 'test-clear-2'
-  script = 'getText("%s")' % id
+  script = 'getText("{0!s}")'.format(id)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
   assert_dom(id, value)
   id = 'test-clear-3'
-  script = 'clearClipboard("%s")' % id
+  script = 'clearClipboard("{0!s}")'.format(id)
   print script
   driver.execute_script(script)
   assert_dom(id, 'success')
   id = 'test-clear-4'
   value = 'abc'
-  script = 'getText("%s")' % id
+  script = 'getText("{0!s}")'.format(id)
   print script
   driver.execute_script(script)
   assert_dom_not(id, value) 

--- a/test/remoting/iframe-remote-neg/test.py
+++ b/test/remoting/iframe-remote-neg/test.py
@@ -24,13 +24,13 @@ html.write('''
     <title>iframe-remote negative test</title>
   </head>
   <body>
-    <iframe src="http://localhost:%s/test.html"></iframe>
+    <iframe src="http://localhost:{0!s}/test.html"></iframe>
     <script>
       document.write('<h1 id="res1">Node is ' + (typeof nw === 'undefined' ? 'DISABLED': 'ENABLED') + '</h1>');
     </script>
   </body>
 </html>
-''' % (port))
+'''.format((port)))
     
 html.close()
 

--- a/test/remoting/iframe-remote/test.py
+++ b/test/remoting/iframe-remote/test.py
@@ -24,13 +24,13 @@ html.write('''
     <title>iframe-remote negative test</title>
   </head>
   <body>
-    <iframe src="http://localhost:%s/test.html"></iframe>
+    <iframe src="http://localhost:{0!s}/test.html"></iframe>
     <script>
       document.write('<h1 id="res1">Node is ' + (typeof nw === 'undefined' ? 'DISABLED': 'ENABLED') + '</h1>');
     </script>
   </body>
 </html>
-''' % (port))
+'''.format((port)))
     
 html.close()
 

--- a/test/remoting/issue4096-download/test.py
+++ b/test/remoting/issue4096-download/test.py
@@ -21,18 +21,18 @@ html.write('''
 var http = nw.require('http');
 var fs = nw.require('fs');
 
-function testgc() {
+function testgc() {{
   gc();
   document.write('<h1 id="res">success</h1>');
-}
+}}
 
 var file = fs.createWriteStream("out.png");
-var req = http.get("http://localhost:%s/g.png", function (res) {
+var req = http.get("http://localhost:{0!s}/g.png", function (res) {{
     res.pipe(file);
     setTimeout(testgc, 1000);
-});
+}});
 </script>
-''' % (port))
+'''.format((port)))
     
 html.close()
 

--- a/test/remoting/issue4131-form-post/test.py
+++ b/test/remoting/issue4131-form-post/test.py
@@ -14,7 +14,7 @@ time.sleep(1)
 try:
     driver.implicitly_wait(10)
     print driver.current_url
-    driver.execute_script('startServer(%s)' % utils.free_port())
+    driver.execute_script('startServer({0!s})'.format(utils.free_port()))
     result = driver.find_element_by_id('server-started').get_attribute('innerHTML')
     print 'server started'
     driver.find_element_by_id('submit').click()

--- a/test/remoting/issue4221-win-open-manifest/test.py
+++ b/test/remoting/issue4221-win-open-manifest/test.py
@@ -15,7 +15,7 @@ def click_and_assert(driver, id, expect):
     driver.switch_to_window(driver.window_handles[-1])
     driver.find_element_by_id('getwinsize').click()
     result = driver.find_element_by_id('result').get_attribute('innerHTML')
-    print 'window size: %s' % result
+    print 'window size: {0!s}'.format(result)
     assert (expect in result)
     driver.close()
     wait_window_handles(driver, 1)

--- a/test/remoting/issue4269-click-link-crash/test.py
+++ b/test/remoting/issue4269-click-link-crash/test.py
@@ -41,7 +41,7 @@ try:
     wait_window_handles(driver, 4)
     driver.switch_to_window(driver.window_handles[3])
     print driver.current_url
-    assert(('http://localhost:%s/inspect.html' % port) in driver.current_url)
+    assert(('http://localhost:{0!s}/inspect.html'.format(port)) in driver.current_url)
 finally:
     server.terminate()
     driver.quit()

--- a/test/remoting/issue4286-inject-start-end/test.py
+++ b/test/remoting/issue4286-inject-start-end/test.py
@@ -16,10 +16,10 @@ try:
     print driver.current_url
     wait_window_handles(driver, 2)
     result = driver.find_element_by_id('inject_start').get_attribute('innerHTML')
-    print 'inject_js_start: %s' % result
+    print 'inject_js_start: {0!s}'.format(result)
     assert('success' in result)
     result = driver.find_element_by_id('inject_end').get_attribute('innerHTML')
-    print 'inject_js_end: %s' % result
+    print 'inject_js_end: {0!s}'.format(result)
     assert('success' in result)
 finally:
     driver.quit()

--- a/test/remoting/issue4493-win-open-size/test.py
+++ b/test/remoting/issue4493-win-open-size/test.py
@@ -16,10 +16,10 @@ time.sleep(1)
 try:
     print driver.current_url
     size = driver.find_element_by_id('size').get_attribute('innerHTML')
-    print 'open size %s' % size
+    print 'open size {0!s}'.format(size)
     driver.find_element_by_id('resize-window').click()
     size = driver.find_element_by_id('resize').get_attribute('innerHTML')
-    print 'resize to %s' % size
+    print 'resize to {0!s}'.format(size)
 finally:
     driver.quit()
 
@@ -31,7 +31,7 @@ time.sleep(1)
 try:
     print driver.current_url
     size = driver.find_element_by_id('size').get_attribute('innerHTML')
-    print 'open size %s' % size
+    print 'open size {0!s}'.format(size)
     assert(size == '666x333')
 finally:
     driver.quit()

--- a/test/remoting/issue4579-capture-remote/test.py
+++ b/test/remoting/issue4579-capture-remote/test.py
@@ -17,12 +17,12 @@ server = subprocess.Popen(['python', 'http-server.py', port])
 
 manifest = open('package.json', 'w')
 manifest.write('''
-{
+{{
   "name":"issue4579-capture-remote",
   "node-remote":"<all_urls>",
-  "main":"http://localhost:%s/index.html"
-}
-''' % (port))
+  "main":"http://localhost:{0!s}/index.html"
+}}
+'''.format((port)))
 manifest.close()
 
 driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])

--- a/test/remoting/node-remote-array/test.py
+++ b/test/remoting/node-remote-array/test.py
@@ -17,12 +17,12 @@ server = subprocess.Popen(['python', 'http-server.py', port])
 
 manifest = open('package.json', 'w')
 manifest.write('''
-{
+{{
   "name":"test-node-remote",
   "node-remote":["<all_urls>"],
-  "main":"http://localhost:%s/index.html"
-}
-''' % (port))
+  "main":"http://localhost:{0!s}/index.html"
+}}
+'''.format((port)))
 manifest.close()
 
 driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])

--- a/test/remoting/node-remote-negtive/test.py
+++ b/test/remoting/node-remote-negtive/test.py
@@ -17,11 +17,11 @@ server = subprocess.Popen(['python', 'http-server.py', port])
 
 manifest = open('package.json', 'w')
 manifest.write('''
-{
+{{
   "name":"test-node-remote",
-  "main":"http://localhost:%s/index.html"
-}
-''' % (port))
+  "main":"http://localhost:{0!s}/index.html"
+}}
+'''.format((port)))
 manifest.close()
 
 driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])

--- a/test/remoting/node-remote/test.py
+++ b/test/remoting/node-remote/test.py
@@ -17,12 +17,12 @@ server = subprocess.Popen(['python', 'http-server.py', port])
 
 manifest = open('package.json', 'w')
 manifest.write('''
-{
+{{
   "name":"test-node-remote",
   "node-remote":"<all_urls>",
-  "main":"http://localhost:%s/index.html"
-}
-''' % (port))
+  "main":"http://localhost:{0!s}/index.html"
+}}
+'''.format((port)))
 manifest.close()
 
 driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_options=chrome_options, service_log_path="log", service_args=["--verbose"])

--- a/test/remoting/nw_util.py
+++ b/test/remoting/nw_util.py
@@ -42,11 +42,11 @@ def switch_to_devtools(driver, devtools_window=None):
 
 def no_live_process(driver, print_if_fail=True):
     if platform.system() == 'Windows':
-        pgrep = subprocess.Popen(['wmic', 'process', 'where', '(ParentProcessId=%s)' % driver.service.process.pid, 'get', 'ProcessId'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        pgrep = subprocess.Popen(['wmic', 'process', 'where', '(ParentProcessId={0!s})'.format(driver.service.process.pid), 'get', 'ProcessId'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         out, err = pgrep.communicate()
         ret = ('No Instance(s) Available.' in out)
         if not ret and print_if_fail:
-            print 'live chrome processes:\n%s' % out
+            print 'live chrome processes:\n{0!s}'.format(out)
         # expect "No Instance(s) Available." in output
         return ret
     else:
@@ -54,7 +54,7 @@ def no_live_process(driver, print_if_fail=True):
         out, err = pgrep.communicate()
         ret = (pgrep.returncode == 1)
         if not ret and print_if_fail:
-            print 'live chrome processes:\n%s' % out
-            print 'pgrep exit with %s' % pgrep.returncode
+            print 'live chrome processes:\n{0!s}'.format(out)
+            print 'pgrep exit with {0!s}'.format(pgrep.returncode)
         # expect exit 1 from pgrep, which means no chrome process alive
         return ret

--- a/test/remoting/open-remote/test.py
+++ b/test/remoting/open-remote/test.py
@@ -21,12 +21,12 @@ server = subprocess.Popen(['python', 'http-server.py', port])
 html = open('index.html', 'w')
 html.write('''
 <script>
-nw.Window.open('http://localhost:%s/remote.html', function(win) {
+nw.Window.open('http://localhost:{0!s}/remote.html', function(win) {{
   document.write('<h1 id="res">returned window is ' + typeof win + '</h1>');
   win.y = 0;
-});
+}});
 </script>
-''' % (port))
+'''.format((port)))
     
 html.close()
 

--- a/test/remoting/package/test.py
+++ b/test/remoting/package/test.py
@@ -45,14 +45,14 @@ def copytree(src, dst, symlinks=False, ignore=None):
             if not os.path.exists(d) or os.stat(s).st_mtime - os.stat(d).st_mtime > 1:
                 shutil.copy2(s, d)
 os.mkdir(pkg1)
-print "copying %s to %s" % (nwdist, pkg1)
+print "copying {0!s} to {1!s}".format(nwdist, pkg1)
 copytree(nwdist, pkg1)
 if platform.system() == 'Darwin':
     appnw = os.path.join(pkg1, 'nwjs.app', 'Contents', 'Resources', 'app.nw')
-    print "copying %s to %s" % (appdir, appnw)
+    print "copying {0!s} to {1!s}".format(appdir, appnw)
     copytree(appdir, appnw)
 else:
-    print "copying %s to %s" % (appdir, pkg1)
+    print "copying {0!s} to {1!s}".format(appdir, pkg1)
     copytree(appdir, pkg1)
 
 #chrome_options = Options()
@@ -72,15 +72,15 @@ finally:
 ######## test compressed package
 
 os.mkdir(pkg2)
-print "copying %s to %s" % (nwdist, pkg2)
+print "copying {0!s} to {1!s}".format(nwdist, pkg2)
 copytree(nwdist, pkg2)
 if platform.system() == 'Darwin':
     appnw = os.path.join(pkg2, 'nwjs.app', 'Contents', 'Resources', 'app.nw')
-    print "compressing %s to %s" % (appdir, appnw)
+    print "compressing {0!s} to {1!s}".format(appdir, appnw)
     compress(appdir, appnw)
 else:
     package_nw = os.path.join(pkg2, 'package.nw')
-    print "compressing %s to %s" % (appdir, package_nw)
+    print "compressing {0!s} to {1!s}".format(appdir, package_nw)
     compress(appdir, package_nw)
 
 driver_path=os.path.join(pkg2, 'chromedriver')
@@ -98,10 +98,10 @@ finally:
 
 if platform.system() != 'Darwin':
     os.mkdir(pkg3)
-    print "copying %s to %s" % (nwdist, pkg3)
+    print "copying {0!s} to {1!s}".format(nwdist, pkg3)
     copytree(nwdist, pkg3)
     package_nw = os.path.join(pkg3, 'package.nw')
-    print "compressing %s to %s" % (appdir, package_nw)
+    print "compressing {0!s} to {1!s}".format(appdir, package_nw)
     compress(appdir, package_nw)
     if platform.system() == 'Linux':
         nwbin = os.path.join(pkg3, 'nw')

--- a/test/remoting/require-path/test.py
+++ b/test/remoting/require-path/test.py
@@ -10,22 +10,22 @@ driver = webdriver.Chrome(executable_path=os.environ['CHROMEDRIVER'], chrome_opt
 try:
     app_path = os.path.dirname(os.path.abspath(__file__))
     public_path = os.path.join(app_path, 'public')
-    print 'current url: %s' % driver.current_url
-    print 'public path: %s' % public_path
+    print 'current url: {0!s}'.format(driver.current_url)
+    print 'public path: {0!s}'.format(public_path)
     time.sleep(1)
     btn = driver.find_element_by_id('btn')
     btn.click()
     result = driver.find_element_by_id('result').get_attribute('innerHTML')
-    print 'require path: %s' % result
+    print 'require path: {0!s}'.format(result)
     assert(public_path == result)
 
     driver.find_element_by_id('lnk').click()
-    print 'current url: %s' % driver.current_url
+    print 'current url: {0!s}'.format(driver.current_url)
     time.sleep(1)
     btn = driver.find_element_by_id('btn')
     btn.click()
     result = driver.find_element_by_id('result').get_attribute('innerHTML')
-    print 'require path: %s' % result
+    print 'require path: {0!s}'.format(result)
     assert(public_path == result)
 finally:
     driver.quit()

--- a/test/remoting/screen-desktopcapturemonitor/test.py
+++ b/test/remoting/screen-desktopcapturemonitor/test.py
@@ -12,7 +12,7 @@ def assert_event_fired(event_name):
         pass
     driver.switch_to_window(base_window)
     assert("success" in driver.find_element_by_id(event_name).get_attribute('innerHTML'))
-    print "%s triggered" % event_name
+    print "{0!s} triggered".format(event_name)
     if tmp_window_handle is not None:
         driver.switch_to_window(tmp_window_handle)
 

--- a/test/remoting/shortcut-creation/test.py
+++ b/test/remoting/shortcut-creation/test.py
@@ -17,7 +17,7 @@ def assert_dom(id, expect):
 def test_shortcut_create(keys, expect="success"):
     key = '+'.join(keys)
     id = 'create-' + '-'.join(keys)
-    reg_script = 'createShortcut("%s", "%s")' % (id, key)
+    reg_script = 'createShortcut("{0!s}", "{1!s}")'.format(id, key)
     print reg_script
     driver.execute_script(reg_script)
     assert_dom(id, expect)

--- a/test/remoting/shortcut-event/test.py
+++ b/test/remoting/shortcut-event/test.py
@@ -17,7 +17,7 @@ def assert_dom(id, expect):
 def test_reg(keys, pykeys=None, expect="success"):
     key = '+'.join(keys)
     id = 'reg-' + '-'.join(keys)
-    reg_script = 'reg("%s", "%s")' % (id, key)
+    reg_script = 'reg("{0!s}", "{1!s}")'.format(id, key)
     print reg_script
     driver.execute_script(reg_script)
     if pykeys is not None:
@@ -28,7 +28,7 @@ def test_reg(keys, pykeys=None, expect="success"):
 def test_unreg(keys, expect="success"):
     key = '+'.join(keys)
     id = 'unreg-' + '-'.join(keys)
-    unreg_script = 'unreg("%s", "%s")' % (id, key)
+    unreg_script = 'unreg("{0!s}", "{1!s}")'.format(id, key)
     print unreg_script
     driver.execute_script(unreg_script)
     assert_dom(id, expect)

--- a/test/remoting/shortcut-failure/test.py
+++ b/test/remoting/shortcut-failure/test.py
@@ -17,7 +17,7 @@ def assert_dom(id, expect):
 def test_reg(keys, pykeys=None, expect="success"):
     key = '+'.join(keys)
     id = 'reg-' + '-'.join(keys)
-    reg_script = 'reg("%s", "%s")' % (id, key)
+    reg_script = 'reg("{0!s}", "{1!s}")'.format(id, key)
     print reg_script
     driver.execute_script(reg_script)
     if pykeys is not None:
@@ -28,7 +28,7 @@ def test_reg(keys, pykeys=None, expect="success"):
 def test_unreg(keys, expect="success"):
     key = '+'.join(keys)
     id = 'unreg-' + '-'.join(keys)
-    unreg_script = 'unreg("%s", "%s")' % (id, key)
+    unreg_script = 'unreg("{0!s}", "{1!s}")'.format(id, key)
     print unreg_script
     driver.execute_script(unreg_script)
     assert_dom(id, expect)

--- a/test/remoting/shortcut-normal/test.py
+++ b/test/remoting/shortcut-normal/test.py
@@ -17,7 +17,7 @@ def assert_dom(id, expect):
 def test_reg(keys, pykeys=None, expect="success"):
     key = '+'.join(keys)
     id = 'reg-' + '-'.join(keys)
-    reg_script = 'reg("%s", "%s")' % (id, key)
+    reg_script = 'reg("{0!s}", "{1!s}")'.format(id, key)
     print reg_script
     driver.execute_script(reg_script)
     if pykeys is not None:
@@ -28,7 +28,7 @@ def test_reg(keys, pykeys=None, expect="success"):
 def test_unreg(keys, expect="success"):
     key = '+'.join(keys)
     id = 'unreg-' + '-'.join(keys)
-    unreg_script = 'unreg("%s", "%s")' % (id, key)
+    unreg_script = 'unreg("{0!s}", "{1!s}")'.format(id, key)
     print unreg_script
     driver.execute_script(unreg_script)
     assert_dom(id, expect)

--- a/test/remoting/testcfg.py
+++ b/test/remoting/testcfg.py
@@ -16,7 +16,7 @@ class RemotingTestCase(test.TestCase):
     self.nwdir = nwdir
 
   def GetTmpDir(self):
-    return "%s.%d" % (self.tmpdir, self.thread_id)
+    return "{0!s}.{1:d}".format(self.tmpdir, self.thread_id)
 
   def GetChromeDriver(self, arch, mode, nwdir):
     if utils.IsWindows():
@@ -31,7 +31,7 @@ class RemotingTestCase(test.TestCase):
       return
 
   def GetLabel(self):
-    return "%s %s" % (self.mode, self.GetName())
+    return "{0!s} {1!s}".format(self.mode, self.GetName())
 
   def GetName(self):
     return self.path[-1]
@@ -84,7 +84,7 @@ class RemotingTestConfiguration(test.TestConfiguration):
     return ['sample', 'sample=shell']
 
   def GetTestStatus(self, sections, defs):
-    status_file = join(self.root, '%s.status' % (self.section))
+    status_file = join(self.root, '{0!s}.status'.format((self.section)))
     if exists(status_file):
       test.ReadConfigurationInto(status_file, sections, defs)
 

--- a/test/remoting/user-agent/echo-user-agent.py
+++ b/test/remoting/user-agent/echo-user-agent.py
@@ -18,7 +18,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         
 def main():
     port = 3456
-    print('Listening on localhost:%s' % port)
+    print('Listening on localhost:{0!s}'.format(port))
     server = HTTPServer(('', port), RequestHandler)
     server.serve_forever()
 

--- a/test/test.py
+++ b/test/test.py
@@ -82,11 +82,11 @@ class ProgressIndicator(object):
       negative_marker = '[negative] '
     else:
       negative_marker = ''
-    print "=== %(label)s %(negative)s===" % {
+    print "=== {label!s} {negative!s}===".format(**{
       'label': test.GetLabel(),
       'negative': negative_marker
-    }
-    print "Path: %s" % "/".join(test.path)
+    })
+    print "Path: {0!s}".format("/".join(test.path))
 
   def Run(self, tasks):
     self.Starting()
@@ -157,7 +157,7 @@ def EscapeCommand(command):
     if ' ' in part:
       # Escape spaces.  We may need to escape more characters for this
       # to work properly.
-      parts.append('"%s"' % part)
+      parts.append('"{0!s}"'.format(part))
     else:
       parts.append(part)
   return " ".join(parts)
@@ -166,7 +166,7 @@ def EscapeCommand(command):
 class SimpleProgressIndicator(ProgressIndicator):
 
   def Starting(self):
-    print 'Running %i tests' % len(self.cases)
+    print 'Running {0:d} tests'.format(len(self.cases))
 
   def Done(self):
     print
@@ -178,7 +178,7 @@ class SimpleProgressIndicator(ProgressIndicator):
       if failed.output.stdout:
         print "--- stdout ---"
         print failed.output.stdout.strip()
-      print "Command: %s" % EscapeCommand(failed.command)
+      print "Command: {0!s}".format(EscapeCommand(failed.command))
       if failed.HasCrashed():
         print "--- CRASHED ---"
       if failed.HasTimedOut():
@@ -190,16 +190,16 @@ class SimpleProgressIndicator(ProgressIndicator):
     else:
       print
       print "==="
-      print "=== %i tests failed" % len(self.failed)
+      print "=== {0:d} tests failed".format(len(self.failed))
       if self.crashed > 0:
-        print "=== %i tests CRASHED" % self.crashed
+        print "=== {0:d} tests CRASHED".format(self.crashed)
       print "==="
 
 
 class VerboseProgressIndicator(SimpleProgressIndicator):
 
   def AboutToRun(self, case):
-    print 'Starting %s...' % case.GetLabel()
+    print 'Starting {0!s}...'.format(case.GetLabel())
     sys.stdout.flush()
 
   def HasRun(self, output):
@@ -210,7 +210,7 @@ class VerboseProgressIndicator(SimpleProgressIndicator):
         outcome = 'FAIL'
     else:
       outcome = 'pass'
-    print 'Done running %s: %s' % (output.test.GetLabel(), outcome)
+    print 'Done running {0!s}: {1!s}'.format(output.test.GetLabel(), outcome)
 
 
 class DotsProgressIndicator(SimpleProgressIndicator):
@@ -240,7 +240,7 @@ class DotsProgressIndicator(SimpleProgressIndicator):
 class TapProgressIndicator(SimpleProgressIndicator):
 
   def Starting(self):
-    logger.info('1..%i' % len(self.cases))
+    logger.info('1..{0:d}'.format(len(self.cases)))
     self._done = 0
 
   def AboutToRun(self, case):
@@ -250,13 +250,13 @@ class TapProgressIndicator(SimpleProgressIndicator):
     self._done += 1
     command = basename(output.command[-1])
     if output.UnexpectedOutput():
-      logger.info('not ok %i - %s' % (self._done, command))
+      logger.info('not ok {0:d} - {1!s}'.format(self._done, command))
       for l in output.output.stderr.splitlines():
         logger.info('#' + l)
       for l in output.output.stdout.splitlines():
         logger.info('#' + l)
     else:
-      logger.info('ok %i - %s' % (self._done, command))
+      logger.info('ok {0:d} - {1!s}'.format(self._done, command))
 
     duration = output.test.duration
 
@@ -265,7 +265,7 @@ class TapProgressIndicator(SimpleProgressIndicator):
       (duration.seconds + duration.days * 24 * 3600) * 10**6) / 10**6
 
     logger.info('  ---')
-    logger.info('  duration_ms: %d.%d' % (total_seconds, duration.microseconds / 1000))
+    logger.info('  duration_ms: {0:d}.{1:d}'.format(total_seconds, duration.microseconds / 1000))
     logger.info('  ...')
 
   def Done(self):
@@ -299,7 +299,7 @@ class CompactProgressIndicator(ProgressIndicator):
       stderr = output.output.stderr.strip()
       if len(stderr):
         print self.templates['stderr'] % stderr
-      print "Command: %s" % EscapeCommand(output.command)
+      print "Command: {0!s}".format(EscapeCommand(output.command))
       if output.HasCrashed():
         print "--- CRASHED ---"
       if output.HasTimedOut():
@@ -437,7 +437,7 @@ class TestCase(object):
 
     try:
       env = self.GetEnv()
-      env.update({"TEST_THREAD_ID": "%d" % self.thread_id})
+      env.update({"TEST_THREAD_ID": "{0:d}".format(self.thread_id)})
       result = self.RunCommand(self.GetCommand(), env)
     finally:
       # Tests can leave the tty in non-blocking mode. If the test runner
@@ -501,7 +501,7 @@ class TestOutput(object):
 
 def KillProcessWithID(pid):
   if utils.IsWindows():
-    os.popen('taskkill /T /F /PID %d' % pid)
+    os.popen('taskkill /T /F /PID {0:d}'.format(pid))
   else:
     os.kill(pid, signal.SIGTERM)
 
@@ -834,7 +834,7 @@ class ListSet(Set):
     self.elms = elms
 
   def __str__(self):
-    return "ListSet%s" % str(self.elms)
+    return "ListSet{0!s}".format(str(self.elms))
 
   def Intersect(self, that):
     if not isinstance(that, ListSet):
@@ -1067,15 +1067,15 @@ def ParseCondition(expr):
   """Parses a logical expression into an Expression object"""
   tokens = Tokenizer(expr).Tokenize()
   if not tokens:
-    print "Malformed expression: '%s'" % expr
+    print "Malformed expression: '{0!s}'".format(expr)
     return None
   scan = Scanner(tokens)
   ast = ParseLogicalExpression(scan)
   if not ast:
-    print "Malformed expression: '%s'" % expr
+    print "Malformed expression: '{0!s}'".format(expr)
     return None
   if scan.HasMore():
-    print "Malformed expression: '%s'" % expr
+    print "Malformed expression: '{0!s}'".format(expr)
     return None
   return ast
 
@@ -1190,7 +1190,7 @@ def ReadConfigurationInto(path, sections, defs):
     if prefix_match:
       prefix = SplitPath(prefix_match.group(1).strip())
       continue
-    print "Malformed line: '%s'." % line
+    print "Malformed line: '{0!s}'.".format(line)
     return False
   return True
 
@@ -1346,7 +1346,7 @@ def GetSuites(test_root):
 
 def FormatTime(d):
   millis = round(d * 1000) % 1000
-  return time.strftime("%M:%S.", time.gmtime(d)) + ("%03i" % millis)
+  return time.strftime("%M:%S.", time.gmtime(d)) + ("{0:03d}".format(millis))
 
 
 def Main():
@@ -1427,7 +1427,7 @@ def Main():
       for mode in options.mode:
         vm = context.GetVm(arch, mode, options.nwdir)
         if not exists(vm):
-          print "Can't find shell executable: '%s'" % vm
+          print "Can't find shell executable: '{0!s}'".format(vm)
           continue
         env = {
           'mode': mode,
@@ -1453,15 +1453,15 @@ def Main():
       if key in visited:
         continue
       visited.add(key)
-      print "--- begin source: %s ---" % test.GetLabel()
+      print "--- begin source: {0!s} ---".format(test.GetLabel())
       source = test.GetSource().strip()
       print source
-      print "--- end source: %s ---" % test.GetLabel()
+      print "--- end source: {0!s} ---".format(test.GetLabel())
     return 0
 
   if options.warn_unused:
     for rule in globally_unused_rules:
-      print "Rule for '%s' was not used." % '/'.join([str(s) for s in rule.path])
+      print "Rule for '{0!s}' was not used.".format('/'.join([str(s) for s in rule.path]))
 
   if options.report:
     PrintReport(all_cases)
@@ -1489,13 +1489,13 @@ def Main():
     # Write the times to stderr to make it easy to separate from the
     # test output.
     print
-    sys.stderr.write("--- Total time: %s ---\n" % FormatTime(duration))
+    sys.stderr.write("--- Total time: {0!s} ---\n".format(FormatTime(duration)))
     timed_tests = [ t.case for t in cases_to_run if not t.case.duration is None ]
     timed_tests.sort(lambda a, b: a.CompareTime(b))
     index = 1
     for entry in timed_tests[:20]:
       t = FormatTime(entry.duration)
-      sys.stderr.write("%4i (%s) %s\n" % (index, t, entry.GetLabel()))
+      sys.stderr.write("{0:4d} ({1!s}) {2!s}\n".format(index, t, entry.GetLabel()))
       index += 1
 
   return result

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -52,7 +52,7 @@ class SimpleTestCase(test.TestCase):
     self.expected_quit_dir = ''
 
   def GetTmpDir(self):
-    return "%s.%d" % (self.tmpdir, self.thread_id)
+    return "{0!s}.{1:d}".format(self.tmpdir, self.thread_id)
 
   
   def AfterRun(self, result):
@@ -102,7 +102,7 @@ class SimpleTestCase(test.TestCase):
       self.expected_quit_dir = ''
   
   def GetLabel(self):
-    return "%s %s" % (self.mode, self.GetName())
+    return "{0!s} {1!s}".format(self.mode, self.GetName())
 
   def GetName(self):
     return self.path[-1]
@@ -151,7 +151,7 @@ class SimpleTestConfiguration(test.TestConfiguration):
     return ['sample', 'sample=shell']
 
   def GetTestStatus(self, sections, defs):
-    status_file = join(self.root, '%s.status' % (self.section))
+    status_file = join(self.root, '{0!s}.status'.format((self.section)))
     if exists(status_file):
       test.ReadConfigurationInto(status_file, sections, defs)
 

--- a/tools/aws_uploader.py
+++ b/tools/aws_uploader.py
@@ -75,7 +75,7 @@ for i in range(len(file_list)):
         break
 
 def print_progress(transmitted, total):
-    print ' %d%% transferred of total: %d bytes.' % (transmitted*100/total, total)
+    print ' {0:d}% transferred of total: {1:d} bytes.'.format(transmitted*100/total, total)
     sys.stdout.flush()
 
 

--- a/tools/build_native_modules.py
+++ b/tools/build_native_modules.py
@@ -46,7 +46,7 @@ if opts.target:
 
 exec_args = ['nw-gyp',
              'configure',
-             '--target=%s'%(target),
+             '--target={0!s}'.format((target)),
              'build']
 
 win = sys.platform in ('win32', 'cygwin')

--- a/tools/commit_id.py
+++ b/tools/commit_id.py
@@ -28,7 +28,7 @@ final_hash = ''
 for repo in repos:
     try:
         repo_path = os.path.join(cwd, repo)
-        final_hash += grab_output('git rev-parse --short=%d HEAD' % commit_id_size, repo_path)
+        final_hash += grab_output('git rev-parse --short={0:d} HEAD'.format(commit_id_size), repo_path)
         final_hash += '-'
     except:
         final_hash = 'invalid-hash'
@@ -37,7 +37,7 @@ for repo in repos:
 final_hash = final_hash.rstrip('-')
 hfile = open(output_file, 'w')
 
-hfile.write('#define NW_COMMIT_HASH "%s"\n'    % final_hash)
-hfile.write('#define NW_COMMIT_HASH_SIZE %d\n' % len(final_hash))
+hfile.write('#define NW_COMMIT_HASH "{0!s}"\n'.format(final_hash))
+hfile.write('#define NW_COMMIT_HASH_SIZE {0:d}\n'.format(len(final_hash)))
 
 hfile.close()

--- a/tools/getnwversion.py
+++ b/tools/getnwversion.py
@@ -14,7 +14,7 @@ for line in f:
   if re.match('#define NW_PATCH_VERSION', line):
     patch = line.split()[2]
 
-nw_version = '%(major)s.%(minor)s.%(patch)s'% locals()  
+nw_version = '{major!s}.{minor!s}.{patch!s}'.format(**locals())  
 
 #print '%(major)s.%(minor)s.%(patch)s'% locals()
 

--- a/tools/package_binaries.py
+++ b/tools/package_binaries.py
@@ -300,7 +300,7 @@ def generate_target_headers(platform_name, arch, version):
             f = open(nw_headers_path, 'rb')
             checksum_file = open(os.path.join(binaries_location, 'SHASUMS256.txt'), 'w')
             with f, checksum_file:
-                checksum_file.write('%s %s' % (sha256(f.read()).hexdigest(), nw_headers_name))
+                checksum_file.write('{0!s} {1!s}'.format(sha256(f.read()).hexdigest(), nw_headers_name))
             shutil.move(nw_headers_path, binaries_location)
             target['input'].append(nw_headers_name)
             target['input'].append('SHASUMS256.txt')

--- a/tools/patch_util.py
+++ b/tools/patch_util.py
@@ -44,7 +44,7 @@ def from_file(filename):
       return PatchInfo() object
   """
 
-  info("reading patch from file %s" % filename)
+  info("reading patch from file {0!s}".format(filename))
   fp = open(filename, "rb")
   patch = PatchInfo(fp)
   fp.close()
@@ -168,7 +168,7 @@ class PatchInfo(object):
             hunkinfo.text.append(line)
             # todo: handle \ No newline cases
         else:
-            msg("invalid hunk no.%d at %d for target file %s" % (nexthunkno, lineno+1, self.target[nextfileno-1]))
+            msg("invalid hunk no.{0:d} at {1:d} for target file {2!s}".format(nexthunkno, lineno+1, self.target[nextfileno-1]))
             # add hunk status node
             self.hunks[nextfileno-1].append(hunkinfo.copy())
             self.hunks[nextfileno-1][nexthunkno-1]["invalid"] = True
@@ -178,7 +178,7 @@ class PatchInfo(object):
 
         # check exit conditions
         if hunkactual["linessrc"] > hunkinfo.linessrc or hunkactual["linestgt"] > hunkinfo.linestgt:
-            msg("extra hunk no.%d lines at %d for target %s" % (nexthunkno, lineno+1, self.target[nextfileno-1]))
+            msg("extra hunk no.{0:d} lines at {1:d} for target {2!s}".format(nexthunkno, lineno+1, self.target[nextfileno-1]))
             # add hunk status node
             self.hunks[nextfileno-1].append(hunkinfo.copy())
             self.hunks[nextfileno-1][nexthunkno-1]["invalid"] = True
@@ -194,11 +194,11 @@ class PatchInfo(object):
             # detect mixed window/unix line ends
             ends = self.hunkends[nextfileno-1]
             if ((ends["cr"]!=0) + (ends["crlf"]!=0) + (ends["lf"]!=0)) > 1:
-              msg("inconsistent line ends in patch hunks for %s" % self.source[nextfileno-1])
+              msg("inconsistent line ends in patch hunks for {0!s}".format(self.source[nextfileno-1]))
             if debugmode:
               debuglines = dict(ends)
               debuglines.update(file=self.target[nextfileno-1], hunk=nexthunkno)
-              debug("crlf: %(crlf)d  lf: %(lf)d  cr: %(cr)d\t - file: %(file)s hunk: %(hunk)d" % debuglines)
+              debug("crlf: {crlf:d}  lf: {lf:d}  cr: {cr:d}\t - file: {file!s} hunk: {hunk:d}".format(**debuglines))
 
       if hunkskip:
         match = re.match("^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))?", line)
@@ -211,19 +211,19 @@ class PatchInfo(object):
           hunkskip = False
           filenames = True
           if debugmode and len(self.source) > 0:
-            debug("- %2d hunks for %s" % (len(self.hunks[nextfileno-1]), self.source[nextfileno-1]))
+            debug("- {0:2d} hunks for {1!s}".format(len(self.hunks[nextfileno-1]), self.source[nextfileno-1]))
 
       if filenames:
         if line.startswith("--- "):
           if nextfileno in self.source:
-            msg("skipping invalid patch for %s" % self.source[nextfileno])
+            msg("skipping invalid patch for {0!s}".format(self.source[nextfileno]))
             del self.source[nextfileno]
             # double source filename line is encountered
             # attempt to restart from this second line
           re_filename = "^--- ([^\t]+)"
           match = re.match(re_filename, line)
           if not match:
-            msg("skipping invalid filename at line %d" % lineno)
+            msg("skipping invalid filename at line {0:d}".format(lineno))
             # switch back to header state
             filenames = False
             header = True
@@ -231,7 +231,7 @@ class PatchInfo(object):
             self.source.append(match.group(1).strip())
         elif not line.startswith("+++ "):
           if nextfileno in self.source:
-            msg("skipping invalid patch with no target for %s" % self.source[nextfileno])
+            msg("skipping invalid patch with no target for {0!s}".format(self.source[nextfileno]))
             del self.source[nextfileno]
           else:
             # this should be unreachable
@@ -240,7 +240,7 @@ class PatchInfo(object):
           header = True
         else:
           if nextfileno in self.target:
-            msg("skipping invalid patch - double target at line %d" % lineno)
+            msg("skipping invalid patch - double target at line {0:d}".format(lineno))
             del self.source[nextfileno]
             del self.target[nextfileno]
             nextfileno -= 1
@@ -252,7 +252,7 @@ class PatchInfo(object):
             re_filename = "^\+\+\+ ([^\t]+)"
             match = re.match(re_filename, line)
             if not match:
-              msg("skipping invalid patch - no target filename at line %d" % lineno)
+              msg("skipping invalid patch - no target filename at line {0:d}".format(lineno))
               # switch back to header state
               filenames = False
               header = True
@@ -272,7 +272,7 @@ class PatchInfo(object):
         match = re.match("^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))?", line)
         if not match:
           if nextfileno-1 not in self.hunks:
-            msg("skipping invalid patch with no hunks for file %s" % self.target[nextfileno-1])
+            msg("skipping invalid patch with no hunks for file {0!s}".format(self.target[nextfileno-1]))
             # switch to header state
             hunkhead = False
             header = True
@@ -304,14 +304,14 @@ class PatchInfo(object):
           continue
     else:
       if not hunkskip:
-        msg("patch file incomplete - %s" % filename)
+        msg("patch file incomplete - {0!s}".format(filename))
         # sys.exit(?)
       else:
         # duplicated message when an eof is reached
         if debugmode and len(self.source) > 0:
-            debug("- %2d hunks for %s" % (len(self.hunks[nextfileno-1]), self.source[nextfileno-1]))
+            debug("- {0:2d} hunks for {1!s}".format(len(self.hunks[nextfileno-1]), self.source[nextfileno-1]))
 
-    info("total files: %d  total hunks: %d" % (len(self.source), sum(len(hset) for hset in self.hunks)))
+    info("total files: {0:d}  total hunks: {1:d}".format(len(self.source), sum(len(hset) for hset in self.hunks)))
 
   def apply(self, root_directory = None):
     """ apply parsed patch """
@@ -327,7 +327,7 @@ class PatchInfo(object):
         if len(self.hunks[fileno]) == 1 and self.hunks[fileno][0].startsrc == 0:
           hunklines = [x[1:].rstrip("\r\n") for x in self.hunks[fileno][0].text if x[0] in " +"]
           if len(hunklines) > 0:
-            msg("creating file %s" % (f2patch))
+            msg("creating file {0!s}".format((f2patch)))
             f = open(f2patch, "wb")
             for line in hunklines:
               f.write(line + "\n")
@@ -336,14 +336,14 @@ class PatchInfo(object):
 
         f2patch = self.target[fileno]
         if not exists(f2patch):
-          msg("source/target file does not exist\n--- %s\n+++ %s" % (filename, f2patch))
+          msg("source/target file does not exist\n--- {0!s}\n+++ {1!s}".format(filename, f2patch))
           continue
       if not isfile(f2patch):
-        msg("not a file - %s" % f2patch)
+        msg("not a file - {0!s}".format(f2patch))
         continue
       filename = f2patch
 
-      info("processing %d/%d:\t %s" % (fileno+1, total, filename))
+      info("processing {0:d}/{1:d}:\t {2!s}".format(fileno+1, total, filename))
 
       # validate before patching
       f2fp = open(filename)
@@ -369,7 +369,7 @@ class PatchInfo(object):
           if line.rstrip("\r\n") == hunkfind[hunklineno]:
             hunklineno+=1
           else:
-            debug("hunk no.%d doesn't match source file %s" % (hunkno+1, filename))
+            debug("hunk no.{0:d} doesn't match source file {1!s}".format(hunkno+1, filename))
             # file may be already patched, but we will check other hunks anyway
             hunkno += 1
             if hunkno < len(self.hunks[fileno]):
@@ -380,7 +380,7 @@ class PatchInfo(object):
 
         # check if processed line is the last line
         if lineno+1 == hunk.startsrc+len(hunkfind)-1:
-          debug("file %s hunk no.%d -- is ready to be patched" % (filename, hunkno+1))
+          debug("file {0!s} hunk no.{1:d} -- is ready to be patched".format(filename, hunkno+1))
           hunkno+=1
           validhunks+=1
           if hunkno < len(self.hunks[fileno]):
@@ -393,29 +393,29 @@ class PatchInfo(object):
       else:
         if hunkno < len(self.hunks[fileno]) and \
             (len(self.hunks[fileno]) != 1 or self.hunks[fileno][0].startsrc != 0):
-          msg("premature end of source file %s at hunk %d" % (filename, hunkno+1))
+          msg("premature end of source file {0!s} at hunk {1:d}".format(filename, hunkno+1))
 
       f2fp.close()
 
       if validhunks < len(self.hunks[fileno]):
         if check_patched(filename, self.hunks[fileno]):
-          msg("already patched  %s" % filename)
+          msg("already patched  {0!s}".format(filename))
         else:
-          msg("source file is different - %s" % filename)
+          msg("source file is different - {0!s}".format(filename))
       if canpatch:
         backupname = filename+".orig"
         if exists(backupname):
-          msg("can't backup original file to %s - aborting" % backupname)
+          msg("can't backup original file to {0!s} - aborting".format(backupname))
         else:
           import shutil
           shutil.move(filename, backupname)
           if patch_hunks(backupname, filename, self.hunks[fileno]):
-            msg("successfully patched %s" % filename)
+            msg("successfully patched {0!s}".format(filename))
             unlink(backupname)
           else:
-            msg("error patching file %s" % filename)
+            msg("error patching file {0!s}".format(filename))
             shutil.copy(filename, filename+".invalid")
-            msg("invalid version is saved to %s" % filename+".invalid")
+            msg("invalid version is saved to {0!s}".format(filename)+".invalid")
             # todo: proper rejects
             shutil.move(backupname, filename)
 
@@ -469,7 +469,7 @@ def check_patched(filename, hunks):
           if not len(line):
             raise NoMatch
           if line.rstrip("\r\n") != hline[1:].rstrip("\r\n"):
-            msg("file is not patched - failed hunk: %d" % (hno+1))
+            msg("file is not patched - failed hunk: {0:d}".format((hno+1)))
             raise NoMatch
   except NoMatch:
     matched = False
@@ -513,7 +513,7 @@ def patch_stream(instream, hunks):
 
 
   for hno, h in enumerate(hunks):
-    debug("hunk %d" % (hno+1))
+    debug("hunk {0:d}".format((hno+1)))
     # skip to line just before hunk starts
     while srclineno < h.startsrc:
       yield get_line()
@@ -549,7 +549,7 @@ def patch_hunks(srcname, tgtname, hunks):
   src = open(srcname, "rb")
   tgt = open(tgtname, "wb")
 
-  debug("processing target file %s" % tgtname)
+  debug("processing target file {0!s}".format(tgtname))
 
   tgt.writelines(patch_stream(src, hunks))
 
@@ -571,7 +571,7 @@ from os.path import exists
 import sys
 
 if __name__ == "__main__":
-  opt = OptionParser(usage="%prog [options] unipatch-file", version="python-patch %s" % __version__)
+  opt = OptionParser(usage="%prog [options] unipatch-file", version="python-patch {0!s}".format(__version__))
   opt.add_option("-d", action="store_true", dest="debugmode", help="debug mode")
   (options, args) = opt.parse_args()
 
@@ -583,7 +583,7 @@ if __name__ == "__main__":
   debugmode = options.debugmode
   patchfile = args[0]
   if not exists(patchfile) or not isfile(patchfile):
-    sys.exit("patch file does not exist - %s" % patchfile)
+    sys.exit("patch file does not exist - {0!s}".format(patchfile))
 
 
   if debugmode:

--- a/tools/patcher.py
+++ b/tools/patcher.py
@@ -26,9 +26,9 @@ def normalize_dir(dir):
 def patch_file(patch_file, patch_dir):
   ''' Apply a single patch file in a single directory. '''
   if not os.path.isfile(patch_file):
-    raise Exception('Patch file %s does not exist.' % patch_file)
+    raise Exception('Patch file {0!s} does not exist.'.format(patch_file))
 
-  sys.stdout.write('Reading patch file %s\n' % patch_file)
+  sys.stdout.write('Reading patch file {0!s}\n'.format(patch_file))
   patchObj = from_file(patch_file)
   patchObj.apply(normalize_dir(patch_dir))
 
@@ -38,7 +38,7 @@ def patch_config(config_file):
   patchdir = normalize_dir(os.path.dirname(os.path.abspath(config_file)))
 
   if not os.path.isfile(config_file):
-    raise Exception('Patch config file %s does not exist.' % config_file)
+    raise Exception('Patch config file {0!s} does not exist.'.format(config_file))
 
   # Parse the configuration file.
   scope = {}
@@ -52,7 +52,7 @@ def patch_config(config_file):
     if 'condition' in patch:
       # Check that the environment variable is set.
       if patch['condition'] not in os.environ:
-        sys.stdout.write('Skipping patch file %s\n' % file)
+        sys.stdout.write('Skipping patch file {0!s}\n'.format(file))
         dopatch = False
 
     if dopatch:
@@ -60,7 +60,7 @@ def patch_config(config_file):
       if 'note' in patch:
         separator = '-' * 79 + '\n'
         sys.stdout.write(separator)
-        sys.stdout.write('NOTE: %s\n' % patch['note'])
+        sys.stdout.write('NOTE: {0!s}\n'.format(patch['note']))
         sys.stdout.write(separator)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:nw.js?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:nw.js?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
